### PR TITLE
Support for i64 primitives

### DIFF
--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -22,9 +22,9 @@ let example1_module : wasm_module =
               WI_Nop;
               WI_LocalGet 0;
               WI_LocalGet 1;
-              WI_BinOp Add;
-              WI_Const 0;
-              WI_BinOp Eq;
+              WI_BinOp (Add, I32);
+              WI_Const (0, I32);
+              WI_BinOp (Eq, I32);
               WI_LocalSet 0
               (* WI_If
                      ( FunType ([], Public, []),
@@ -69,11 +69,11 @@ let store_and_load_module (mem_size : int) (store_addr : int) (load_addr : int)
           locals = [ { t = I32; lbl = Public } ];
           body =
             [
-              WI_Const store_addr;
+              WI_Const (store_addr, I32);
               WI_LocalGet 0;
-              WI_Store store_label;
-              WI_Const load_addr;
-              WI_Load load_label;
+              WI_Store (store_label, I32);
+              WI_Const (load_addr, I32);
+              WI_Load (load_label, I32);
             ];
           export_name = Some "foo";
         };
@@ -103,7 +103,7 @@ let bubblesort_module : wasm_module =
     memory = Some { size = 10 };
     globals =
       [ { (* length *)
-          gtype = i32Public; const = [ WI_Const 10 ]; mut = true } ];
+          gtype = i32Public; const = [ WI_Const (10, I32) ]; mut = true } ];
     function_imports =
       [
         ("env", "write_char", FunType ([ i32Public ], Public, []));
@@ -120,7 +120,7 @@ let bubblesort_module : wasm_module =
             [
               WI_LocalGet 0;
               WI_GlobalSet 0;
-              WI_Const 0;
+              WI_Const (0, I32);
               WI_LocalGet 0;
               WI_Call 4 (* init_vals *);
             ];
@@ -137,18 +137,18 @@ let bubblesort_module : wasm_module =
           body =
             [
               WI_LocalGet 1;
-              WI_Const 0;
-              WI_BinOp Eq;
+              WI_Const (0, I32);
+              WI_BinOp (Eq, I32);
               WI_BrIf 0 (* return *);
               WI_LocalGet 0;
               WI_Call 2 (* get_random *);
-              WI_Store Public;
+              WI_Store (Public, I32);
               WI_LocalGet 0;
-              WI_Const 4;
-              WI_BinOp Add;
+              WI_Const (4 , I32);
+              WI_BinOp (Add, I32);
               WI_LocalGet 1;
-              WI_Const 1;
-              WI_BinOp Sub;
+              WI_Const (1, I32);
+              WI_BinOp (Sub, I32);
               WI_Call 4 (* self *);
             ];
           export_name = None;
@@ -159,13 +159,13 @@ let bubblesort_module : wasm_module =
           locals = [];
           body =
             [
-              WI_Const 40 (* ( *);
+              WI_Const (40, I32) (* ( *);
               WI_Call 0;
-              WI_Const 0;
+              WI_Const (0, I32);
               WI_Call 6;
-              WI_Const 32 (* space *);
+              WI_Const (32, I32) (* space *);
               WI_Call 0;
-              WI_Const 41 (* ) *);
+              WI_Const (41, I32) (* ) *);
               WI_Call 0;
             ];
           export_name = Some "print";
@@ -178,18 +178,18 @@ let bubblesort_module : wasm_module =
             [
               WI_LocalGet 0;
               WI_GlobalGet 0;
-              WI_BinOp Ge_s;
+              WI_BinOp (Ge_s, I32);
               WI_BrIf 0;
-              WI_Const 32 (* space *);
+              WI_Const (32, I32) (* space *);
               WI_Call 0 (* write_char *);
               WI_LocalGet 0;
-              WI_Const 4;
-              WI_BinOp Mul;
-              WI_Load Public;
+              WI_Const (4, I32);
+              WI_BinOp (Mul, I32);
+              WI_Load (Public, I32);
               WI_Call 1 (* write_int*);
               WI_LocalGet 0;
-              WI_Const 1;
-              WI_BinOp Add;
+              WI_Const (1, I32);
+              WI_BinOp (Add, I32);
               WI_Call 6 (* self*);
             ];
           export_name = None;
@@ -199,11 +199,11 @@ let bubblesort_module : wasm_module =
           locals = [];
           body =
             [
-              WI_Const 0;
-              WI_Const 0;
+              WI_Const (0, I32);
+              WI_Const (0, I32);
               WI_Call 8;
-              WI_Const 0;
-              WI_BinOp Eq;
+              WI_Const (0, I32);
+              WI_BinOp (Eq, I32);
               WI_BrIf 0 (* return *);
               WI_Call 7 (* sort helper *);
             ];
@@ -223,49 +223,49 @@ let bubblesort_module : wasm_module =
                   [
                     WI_LocalGet 1;
                     WI_GlobalGet 0;
-                    WI_Const 2;
-                    WI_BinOp Sub;
+                    WI_Const (2, I32);
+                    WI_BinOp (Sub, I32);
                     WI_LocalGet 0;
-                    WI_BinOp Lt_s;
+                    WI_BinOp (Lt_s, I32);
                     WI_BrIf 1;
                     WI_Drop;
                   ] );
               WI_LocalGet 0;
-              WI_Const 4;
-              WI_BinOp Mul;
+              WI_Const (4, I32);
+              WI_BinOp (Mul, I32);
               WI_LocalSet 2;
               WI_LocalGet 0;
-              WI_Const 1;
-              WI_BinOp Add;
-              WI_Const 4;
-              WI_BinOp Mul;
+              WI_Const (1, I32);
+              WI_BinOp (Add, I32);
+              WI_Const (4, I32);
+              WI_BinOp (Mul, I32);
               WI_LocalSet 3;
               WI_Block
                 ( BlockType ([], []),
                   [
                     (* swap *)
                     WI_LocalGet 2;
-                    WI_Load Public;
+                    WI_Load (Public, I32);
                     WI_LocalGet 3;
-                    WI_Load Public;
-                    WI_BinOp Le_s;
+                    WI_Load (Public, I32);
+                    WI_BinOp (Le_s, I32);
                     WI_BrIf 0;
                     WI_LocalGet 2;
-                    WI_Load Public;
+                    WI_Load (Public, I32);
                     WI_LocalSet 4;
                     WI_LocalGet 2;
                     WI_LocalGet 3;
-                    WI_Load Public;
-                    WI_Store Public;
+                    WI_Load (Public, I32);
+                    WI_Store (Public, I32);
                     WI_LocalGet 3;
                     WI_LocalGet 4;
-                    WI_Store Public;
-                    WI_Const 1;
+                    WI_Store (Public, I32);
+                    WI_Const (1, I32);
                     WI_LocalSet 1;
                   ] );
               WI_LocalGet 0;
-              WI_Const 1;
-              WI_BinOp Add;
+              WI_Const (1, I32);
+              WI_BinOp (Add, I32);
               WI_LocalGet 1;
               WI_Call 8;
             ];
@@ -304,23 +304,23 @@ let sequential_mem_store_module (mem_size : int) =
                           WI_LocalGet 0;
                           (* ;; current addr *)
                           WI_LocalGet 2;
-                          WI_BinOp Lt_s;
+                          WI_BinOp (Lt_s, I32);
                           WI_BrIf 1;
                           WI_LocalGet 2;
                           (* get_random *)
-                          WI_Const 42;
-                          WI_Store Secret;
+                          WI_Const (42, I32);
+                          WI_Store (Secret, I32);
                           WI_LocalGet 2;
                           (* offset *)
                           WI_LocalGet 1;
-                          WI_BinOp Add;
+                          WI_BinOp (Add, I32);
                           (* save new addr *)
                           WI_LocalSet 3;
                           WI_LocalGet 3;
                           (* load old addr *)
                           WI_LocalGet 2;
                           (* check for overflow *)
-                          WI_BinOp Lt_u;
+                          WI_BinOp (Lt_u, I32);
                           WI_BrIf 1;
                           WI_LocalGet 3;
                           WI_LocalSet 2;
@@ -359,21 +359,21 @@ let sequential_mem_store_load_module (mem_size : int) =
                           (* max addr, e.g. 2 ^ ((log memory.size) + 16) - 4 *)
                           WI_LocalGet 2;
                           (* ;; current addr *)
-                          WI_BinOp Lt_s;
+                          WI_BinOp (Lt_s, I32);
                           WI_BrIf 1;
                           WI_LocalGet 2;
-                          WI_Const 42;
-                          WI_Store Secret;
+                          WI_Const (42, I32);
+                          WI_Store (Secret, I32);
                           WI_LocalGet 2;
                           WI_LocalGet 1;
                           (* offset *)
-                          WI_BinOp Add;
+                          WI_BinOp (Add, I32);
                           WI_LocalSet 3;
                           (* save new addr *)
                           WI_LocalGet 3;
                           WI_LocalGet 2;
                           (* load old addr *)
-                          WI_BinOp Lt_u;
+                          WI_BinOp (Lt_u, I32);
                           (* check for overflow *)
                           WI_BrIf 1;
                           WI_LocalGet 3;

--- a/src/lib/ast.ml
+++ b/src/lib/ast.ml
@@ -188,7 +188,10 @@ let pp_function (f : wasm_func) =
   "(func" ^ export ^ params ^ result ^ nl ^ locals ^ nl ^ body ^ nl ^ ")"
 
 let pp_global g =
-  let t = if g.mut then "(mut i32)" else "i32"
+  let t = 
+    match g.gtype.t with
+    | I32 -> if g.mut then "(mut i32)" else "i32"
+    | I64 -> if g.mut then "(mut i64)" else "i64"
   and init =
     match g.const with
     | [ instr ] -> pp_instruction 0 instr

--- a/src/lib/ast.ml
+++ b/src/lib/ast.ml
@@ -2,7 +2,9 @@ open Sec
 
 [@@@coverage exclude_file]
 
-type value_type = I32
+type value_type = 
+  | I32
+  | I64
 
 (* This is equivalent to tau in the paper (typing judgements) *)
 type labeled_value_type = { t : value_type; lbl : SimpleLattice.t }
@@ -29,15 +31,15 @@ type binop =
 type wasm_instruction =
   | WI_Unreachable                                                    (* trap unconditionally *)
   | WI_Drop                                                           (* drop value *)
-  | WI_Const of int                                                   (* constant *)
-  | WI_BinOp of binop                                                 (* binary numeric operator, deviates a bit from spec *)
+  | WI_Const of (int * value_type)                                    (* constant *)
+  | WI_BinOp of (binop * value_type)                                  (* binary numeric operator, deviates a bit from spec *)
   | WI_Call of int                                                    (* call function *)
   | WI_LocalGet of int                                                (* read local variable *)
   | WI_LocalSet of int                                                (* write local variable *)
   | WI_GlobalGet of int                                               (* read global variable *)
   | WI_GlobalSet of int                                               (* write global variable *)
-  | WI_Load of SimpleLattice.t                                        (* read memory at address *)
-  | WI_Store of SimpleLattice.t                                       (* write memory at address *)
+  | WI_Load of (SimpleLattice.t * value_type)                         (* read memory at address *)
+  | WI_Store of (SimpleLattice.t * value_type)                        (* write memory at address *)
   | WI_Block of block_type * wasm_instruction list                    (* block *)
   | WI_Loop of block_type * wasm_instruction list                     (* loop *)
   | WI_Br of int                                                      (* unconditional branch *)
@@ -70,10 +72,12 @@ type wasm_module = {
 
 (************************* PRETTY PRINTING ************************************)
 
-let pp_type (t : value_type) = match t with I32 -> "i32"
+let pp_type (t : value_type) = match t with 
+  | I32 -> "i32"
+  | I64 -> "i64"
 
 let pp_labeled_type (t : labeled_value_type) =
-  pp_type t.t (* TODO: have separate pp *)
+  pp_type t.t (* TODO: have separate pp <== what is meant by this? *)
 
 let nl = "\n"
 
@@ -110,27 +114,29 @@ let rec pp_instruction (indent : int) (instr : wasm_instruction) =
   match instr with
   | WI_Unreachable -> "unreachable"
   | WI_Nop -> "nop"
-  | WI_Const v -> "i32.const " ^ Int.to_string v
-  | WI_BinOp Add -> "i32.add"
-  | WI_BinOp Mul -> "i32.mul"
-  | WI_BinOp Eq -> "i32.eq"
-  | WI_BinOp Ge_s -> "i32.ge_s"
-  | WI_BinOp Le_s -> "i32.le_s"
-  | WI_BinOp Lt_s -> "i32.lt_s"
-  | WI_BinOp Lt_u -> "i32.lt_u"
-  | WI_BinOp Sub -> "i32.sub"
-  | WI_BinOp Shr_u -> "i32.shr_u"
-  | WI_BinOp Shl -> "i32.shl"
-  | WI_BinOp And -> "i32.and"
-  | WI_BinOp Or -> "i32.or"
+  | WI_Const (v, value_type) -> (pp_type value_type) ^ ".const " ^ Int.to_string v 
+  | WI_BinOp (binop, value_type) ->
+    match binop with ->
+    | Add -> (pp_type value_type) ^ ".add"
+    | Mul -> (pp_type value_type) ^ ".mul"
+    | Eq -> (pp_type value_type) ^ ".eq"
+    | Ge_s -> (pp_type value_type) ^ ".ge_s"
+    | Le_s -> (pp_type value_type) ^ ".le_s"
+    | Lt_s -> (pp_type value_type) ^ ".lt_s"
+    | Lt_u -> (pp_type value_type) ^ ".lt_u"
+    | Sub -> (pp_type value_type) ^ ".sub"
+    | Shr_u -> (pp_type value_type) ^ ".shr_u"
+    | Shl -> (pp_type value_type) ^ ".shl"
+    | And -> (pp_type value_type) ^ ".and"
+    | Or -> (pp_type value_type) ^ ".or"
   | WI_Call idx -> "call " ^ Int.to_string idx
   | WI_Drop -> "drop"
   | WI_LocalGet idx -> "local.get " ^ Int.to_string idx
   | WI_LocalSet idx -> "local.set " ^ Int.to_string idx
   | WI_GlobalGet idx -> "global.get " ^ Int.to_string idx
   | WI_GlobalSet idx -> "global.set " ^ Int.to_string idx
-  | WI_Load _ -> "i32.load"
-  | WI_Store _ -> "i32.store"
+  | WI_Load (_, value_type) -> (pp_type value_type) ^ ".load" 
+  | WI_Store (_, value_type) -> (pp_type value_type) ^ ".store"
   | WI_Block (t, b) ->
       "block " ^ pp_block_type t ^ nl
       ^ pp_instructions (indent + 2) b

--- a/src/lib/ast.ml
+++ b/src/lib/ast.ml
@@ -114,29 +114,29 @@ let rec pp_instruction (indent : int) (instr : wasm_instruction) =
   match instr with
   | WI_Unreachable -> "unreachable"
   | WI_Nop -> "nop"
-  | WI_Const (v, value_type) -> (pp_type value_type) ^ ".const " ^ Int.to_string v 
-  | WI_BinOp (binop, value_type) ->
-    match binop with ->
-    | Add -> (pp_type value_type) ^ ".add"
-    | Mul -> (pp_type value_type) ^ ".mul"
-    | Eq -> (pp_type value_type) ^ ".eq"
-    | Ge_s -> (pp_type value_type) ^ ".ge_s"
-    | Le_s -> (pp_type value_type) ^ ".le_s"
-    | Lt_s -> (pp_type value_type) ^ ".lt_s"
-    | Lt_u -> (pp_type value_type) ^ ".lt_u"
-    | Sub -> (pp_type value_type) ^ ".sub"
-    | Shr_u -> (pp_type value_type) ^ ".shr_u"
-    | Shl -> (pp_type value_type) ^ ".shl"
-    | And -> (pp_type value_type) ^ ".and"
-    | Or -> (pp_type value_type) ^ ".or"
+  | WI_Const (v, vt) -> (pp_type vt) ^ ".const " ^ Int.to_string v 
+  | WI_BinOp (bop, vt) ->
+    (match bop with
+    | Add -> (pp_type vt) ^ ".add"
+    | Mul -> (pp_type vt) ^ ".mul"
+    | Eq -> (pp_type vt) ^ ".eq"
+    | Ge_s -> (pp_type vt) ^ ".ge_s"
+    | Le_s -> (pp_type vt) ^ ".le_s"
+    | Lt_s -> (pp_type vt) ^ ".lt_s"
+    | Lt_u -> (pp_type vt) ^ ".lt_u"
+    | Sub -> (pp_type vt) ^ ".sub"
+    | Shr_u -> (pp_type vt) ^ ".shr_u"
+    | Shl -> (pp_type vt) ^ ".shl"
+    | And -> (pp_type vt) ^ ".and"
+    | Or -> (pp_type vt) ^ ".or")
   | WI_Call idx -> "call " ^ Int.to_string idx
   | WI_Drop -> "drop"
   | WI_LocalGet idx -> "local.get " ^ Int.to_string idx
   | WI_LocalSet idx -> "local.set " ^ Int.to_string idx
   | WI_GlobalGet idx -> "global.get " ^ Int.to_string idx
   | WI_GlobalSet idx -> "global.set " ^ Int.to_string idx
-  | WI_Load (_, value_type) -> (pp_type value_type) ^ ".load" 
-  | WI_Store (_, value_type) -> (pp_type value_type) ^ ".store"
+  | WI_Load (_, vt) -> (pp_type vt) ^ ".load" 
+  | WI_Store (_, vt) -> (pp_type vt) ^ ".store"
   | WI_Block (t, b) ->
       "block " ^ pp_block_type t ^ nl
       ^ pp_instructions (indent + 2) b

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -232,7 +232,7 @@ let rec check_instr ((g, c) : stack_of_stacks_type * context)
       | WI_Nop -> (g, c)
       | WI_Drop -> (
           match st with _ :: st' -> ((st', pc) :: g', c) | _ -> raise err_drop)
-      | WI_Const _ -> (({ t = I32; lbl = pc } :: st, pc) :: g', c)
+      | WI_Const (_, vt) -> (({ t = vt; lbl = pc } :: st, pc) :: g', c)
       | WI_BinOp _ -> (
           match st with
           | v1 :: v2 :: st' ->
@@ -282,17 +282,17 @@ let rec check_instr ((g, c) : stack_of_stacks_type * context)
               if not (l <> pc <<= l') then raise (err_globalset2 pc l l');
               ((st', pc) :: g', c)
           | _ -> raise err_globalset3)
-      | WI_Load lm -> (
+      | WI_Load (lm, _) -> (
           match c.memory with
           | None -> raise err_load_nomemory
           | Some _ -> (
               match st with
-              | { t = _; lbl = la } :: st ->
+              | { t; lbl = la } :: st ->
                   (* l = l_a ⊔ l_m ⊔ pc *)
                   let lbl = la <> lm <> pc in
-                  (({ t = I32; lbl } :: st, pc) :: g', c)
+                  (({ t; lbl } :: st, pc) :: g', c)
               | _ -> raise err_load_addrexists))
-      | WI_Store lm -> (
+      | WI_Store (lm, _) -> (
           match c.memory with
           | None -> raise err_store_nomemory
           | Some _ -> (

--- a/src/tests/test_secwasm.ml
+++ b/src/tests/test_secwasm.ml
@@ -18,7 +18,7 @@ let test (name : string) (t : wasm_module -> test_ctxt -> unit)
     (m : wasm_module) =
   test_list := !test_list @ [ name >:: t m ]
 
-(* ======= Modules under test  ========= *)
+(* ======= I32 Modules under test  ========= *)
 
 (*
   Add two constants
@@ -2191,6 +2191,2188 @@ let _ =
                             [ WI_GlobalGet 0; WI_Const (0, I32); WI_BinOp (Eq, I32); WI_BrIf 0; WI_Br 1]
                           );
                         WI_Const (1, I32);
+                        WI_GlobalSet 1;
+                      ] );
+                ];
+              export_name = None;
+            };
+          ];
+      }
+
+
+(* ======= I64 Modules under test  ========= *)
+
+(*
+  Add two constants
+
+  (module
+    (func
+      (result i64)
+      i64.const 1
+      i64.const 1
+      i64.add
+    )
+  )
+*)
+
+let _ =
+  test "add consts" pos_test
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, [ { t = I64; lbl = Public } ]);
+            locals = [];
+            body = [ WI_Const (1, I64); WI_Const (1, I64); WI_BinOp (Add, I64) ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Add is missing an operand
+
+  (module
+    (func
+      (result i64)
+      i64.const 1
+      i64.add
+    )
+  )
+*)
+let _ =
+  test "add consts 2" (neg_test err_binop)
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, [ { t = I64; lbl = Public } ]);
+            locals = [];
+            body = [ WI_Const (1, I64); WI_BinOp (Add, I64) ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Nop is well-typed
+
+  (module
+    (func
+      nop
+    )
+  )
+*)
+let _ =
+  test "nop" pos_test
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [ { t = I64; lbl = Public } ];
+            body = [ WI_Nop ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Unreachable is well-typed
+
+  (module
+    (func
+      unreachable
+    )
+  )
+*)
+let _ =
+  test "unreachable" pos_test
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body = [ WI_Unreachable ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Push a constant, drop it again
+
+  (module
+    (func
+      i64.const 42
+      drop
+    )
+  )
+*)
+let _ =
+  test "drop" pos_test
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [ { t = I64; lbl = Public } ];
+            body = [ WI_Const (42, I64); WI_Drop ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Nothing to drop
+
+  (module
+    (func
+      drop
+    )
+  )
+*)
+let _ =
+  test "drop 2" (neg_test err_drop)
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [ { t = I64; lbl = Public } ];
+            body = [ WI_Drop ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Get a public local variable
+
+  (module
+    (func
+      (local i64)
+      local.get 0
+      drop
+    )
+  )
+*)
+let _ =
+  test "local.get" pos_test
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [ { t = I64; lbl = Public } ];
+            body = [ WI_LocalGet 0; WI_Drop ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Get non-existing local variable
+
+  (module
+    (func
+      local.get 0
+      drop
+    )
+  )
+*)
+let _ =
+  test "local.get non-existing local"
+    (neg_test (TypingError "did not find local variable of index 0"))
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body = [ WI_LocalGet 0 ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Set a public global variable
+
+  (module
+    (global (mut i64) (i64.const 0))
+    (func
+      i64.const 42
+      global.set 0
+    )
+  )
+*)
+let _ =
+  test "global.set" pos_test
+    {
+      memory = None;
+      globals =
+        [
+          {
+            gtype = { t = I64; lbl = Public };
+            const = [ WI_Const (0, I64) ];
+            mut = true;
+          };
+        ];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body = [ WI_Const (42, I64); WI_GlobalSet 0 ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Set global fails (no variable provided)
+
+  (module
+    (global i64 (i64.const 0))
+    (func
+      global.set 0
+    )
+  )
+*)
+let _ =
+  test "local.set no variable provided"
+    (neg_test (TypingError "global.set expected 1 value on the stack"))
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [ { t = I64; lbl = Public } ];
+            body = [ WI_GlobalSet 0 ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Set a non-mut public global variable
+
+  (module
+    (global i64 (i64.const 0))
+    (func
+      i64.const 42
+      global.set 0
+    )
+  )
+*)
+let _ =
+  test "set non-mut global var"
+    (neg_test (TypingError "global.set expected global var to be mutable"))
+    {
+      memory = None;
+      globals =
+        [
+          {
+            gtype = { t = I64; lbl = Public };
+            const = [ WI_Const (0, I64) ];
+            mut = false;
+          };
+        ];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body = [ WI_Const (42, I64); WI_GlobalSet 0 ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Set a non-existing public global variable
+
+  (module
+    (func
+      i64.const 42
+      global.set 0
+    )
+  )
+*)
+let _ =
+  test "set non-existing global var"
+    (neg_test (TypingError "did not find global variable of index 0"))
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body = [ WI_Const (42, I64); WI_GlobalSet 0 ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Forbidden explicit flow from secret global variable to public global variable
+
+  (module
+    (global i64 (i64.const 0))       ;; secret
+    (global (mut i64) (i64.const 0)) ;; public
+    (func
+      global.get 0
+      i64.const 1
+      i64.add
+      global.set 1
+    )
+  )
+*)
+let _ =
+  test "forbidden explicit flow (global vars)"
+    (neg_test
+       (PrivacyViolation
+          "global.set expected pc \226\138\148 l \226\138\145 l' but was \
+           pc=Public, l=Secret, l'=Public"))
+    {
+      memory = None;
+      globals =
+        [
+          {
+            gtype = { t = I64; lbl = Secret };
+            const = [ WI_Const (0, I64) ];
+            mut = false;
+          };
+          {
+            gtype = { t = I64; lbl = Public };
+            const = [ WI_Const (0, I64) ];
+            mut = true;
+          };
+        ];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body = [ WI_GlobalGet 0; WI_Const (1, I64); WI_BinOp (Add, I64); WI_GlobalSet 1 ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Set a public local variable
+
+  (module
+    (func
+      (local i64)
+      i64.const 42
+      local.set 0
+    )
+  )
+*)
+let _ =
+  test "local.set" pos_test
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [ { t = I64; lbl = Public } ];
+            body = [ WI_Const (42, I64); WI_LocalSet 0 ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Set local fails (no variable provided)
+
+  (module
+    (func
+      (local i64)
+      local.set 0
+    )
+  )
+*)
+let _ =
+  test "local.set no variable provided"
+    (neg_test (TypingError "local.set expected 1 value on the stack"))
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [ { t = I64; lbl = Public } ];
+            body = [ WI_LocalSet 0 ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Forbidden direct flow to public local
+
+  (module
+    (global i64 (i64.const 0)) <Secret>
+    (func
+      (local i64) <Public>
+      global.get 0
+      local.set 0
+    )
+  )
+*)
+let _ =
+  test "forbidden flow to public local"
+    (neg_test
+       (PrivacyViolation
+          "local.set expected pc \226\138\148 l \226\138\145 l' but was \
+           pc=Public, l=Secret, l'=Public"))
+    {
+      memory = None;
+      globals =
+        [
+          {
+            gtype = { t = I64; lbl = Secret };
+            const = [ WI_Const (0, I64) ];
+            mut = false;
+          };
+        ];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [ { t = I64; lbl = Public } ];
+            body = [ WI_GlobalGet 0; WI_LocalSet 0 ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Load from memory
+
+  (module
+    (memory 1)
+    (func (result i64)
+      i64.const 0
+      i64.load
+    )
+  )
+*)
+let _ =
+  test "load" pos_test
+    {
+      memory = Some { size = 1 };
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, [ { t = I64; lbl = Public } ]);
+            locals = [];
+            body = [ WI_Const (0, I64); WI_Load (Public, I64) ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Load fails when no addr provided
+
+  (module
+    (memory 1)
+    (func (result i64)
+      i64.load
+    )
+  )
+*)
+let _ =
+  test "load"
+    (neg_test (TypingError "load expected 1 value on the stack"))
+    {
+      memory = Some { size = 1 };
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, [ { t = I64; lbl = Public } ]);
+            locals = [];
+            body = [ WI_Load (Public, I64) ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Load no memory present
+
+  (module
+    (func
+      i64.const 0
+      i64.load
+    )
+  )
+*)
+let _ =
+  test "load no memory present "
+    (neg_test (TypingError "load expected memory in the context"))
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, [ { t = I64; lbl = Public } ]);
+            locals = [];
+            body = [ WI_Const (0, I64); WI_Load (Public, I64) ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Store no memory present
+
+  (module
+    (func
+      i64.const 0
+      i64.load
+    )
+  )
+*)
+let _ =
+  test "store no memory present "
+    (neg_test (TypingError "store expected memory in the context"))
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body = [ WI_Const (0, I64); WI_Const (0, I64); WI_Store (Public, I64) ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Store to memory
+
+  (module
+    (memory 1)
+    (func
+      i64.const 0
+      i64.const 42
+      i64.store
+    )
+  )
+*)
+let _ =
+  test "store" pos_test
+    {
+      memory = Some { size = 1 };
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body = [ WI_Const (0, I64); WI_Const (42, I64); WI_Store (Public, I64) ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Storing secret value in public memory is forbidden
+
+  (module
+    (memory 1)
+    (global i64 (i64.const 0)) <Secret>
+    (func
+      i64.const 0
+      global.get 0
+      i64.store Public
+    )
+  )
+*)
+let _ =
+  test "store secret value in public memory"
+    (neg_test
+       (PrivacyViolation
+          "store expected pc ⊔ la ⊔ lv ⊑ lm but was pc=Public, la=Public, \
+           lv=Secret, lm=Public"))
+    {
+      memory = Some { size = 1 };
+      globals =
+        [
+          {
+            gtype = { t = I64; lbl = Secret };
+            const = [ WI_Const (0, I64) ];
+            mut = false;
+          };
+        ];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body = [ WI_Const (0, I64); WI_GlobalGet 0; WI_Store (Public, I64) ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Store fails when not enough args provided
+
+  (module
+    (memory 1)
+    (func (result i64)
+      i64.store
+    )
+  )
+*)
+let _ =
+  test "load"
+    (neg_test (TypingError "store expected 2 values on the stack"))
+    {
+      memory = Some { size = 1 };
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, [ { t = I64; lbl = Public } ]);
+            locals = [];
+            body = [ WI_Store (Public, I64) ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Forbidden implicit flow via load from secret address
+
+  (module
+    (memory 3)
+    (global i64 (i64.const 0))       ;; secret
+    (global (mut i64) (i64.const 0)) ;; public
+    (func
+      global.get 0    ;; secret address
+      i64.load Public ;; value itself not secret
+      global.set 1
+    )
+  )
+*)
+let _ =
+  test "forbidden implicit flow via load from secret address"
+    (neg_test
+       (PrivacyViolation
+          "global.set expected pc \226\138\148 l \226\138\145 l' but was \
+           pc=Public, l=Secret, l'=Public"))
+    {
+      memory = Some { size = 1 };
+      globals =
+        [
+          {
+            gtype = { t = I64; lbl = Secret };
+            const = [ WI_Const (0, I64) ];
+            mut = false;
+          };
+          {
+            gtype = { t = I64; lbl = Public };
+            const = [ WI_Const (0, I64) ];
+            mut = true;
+          };
+        ];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body = [ WI_GlobalGet 0; WI_Load (Public, I64); WI_GlobalSet 1 ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Simple block
+
+  (module
+    (func
+      (block
+        nop
+      end)
+    )
+  )
+*)
+let _ =
+  test "block 1" pos_test
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body = [ WI_Block (BlockType ([], []), [ WI_Nop ]) ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Simple nested block
+
+  (module
+    (func
+      (block
+        (block
+          nop
+        end)
+      end)
+    )
+  )
+*)
+let _ =
+  test "nested block" pos_test
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body =
+              [
+                WI_Block
+                  ( BlockType ([], []),
+                    [ WI_Block (BlockType ([], []), [ WI_Nop ]) ] );
+              ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Block with simple params
+
+  (module
+    (func
+      i64.const 42
+      (block i64 L ->
+        drop
+      end)
+    )
+  )
+*)
+let _ =
+  test "block with simple param" pos_test
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body =
+              [
+                WI_Const (42, I64);
+                WI_Block
+                  (BlockType ([ { t = I64; lbl = Public } ], []), [ WI_Drop ]);
+              ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Block with simple params is ill-typed since stack is empty
+
+  (module
+    (func
+      (block i64 L ->
+        nop
+      end)
+    )
+  )
+*)
+let _ =
+  test "block with simple param"
+    (neg_test (err_block1 false 1 0))
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body =
+              [
+                WI_Block
+                  (BlockType ([ { t = I64; lbl = Public } ], []), [ WI_Nop ]);
+              ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Block with simple params is ill-typed since stack is empty
+
+  (module
+    (func
+      (block i64 L ->
+        drop
+      end)
+    )
+  )
+*)
+let _ =
+  test "block with simple param 2"
+    (neg_test (err_block2 false 1 0))
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body =
+              [
+                WI_Const (42, I64);
+                WI_Block
+                  ( BlockType
+                      ( [ { t = I64; lbl = Public } ],
+                        [ { t = I64; lbl = Public } ] ),
+                    [ WI_Drop ] );
+              ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Block input stack has higher security level than block params security level
+
+  (module
+    (global i64<Secret> (i64.const 42))
+    (func
+      global.get 0
+      (block i64<Public> -> ϵ
+        drop
+      end)
+    )
+  )
+*)
+let _ =
+  test "block input stack incorrect security level"
+    (neg_test
+       (err_block3 false
+          [ { t = I64; lbl = Public } ]
+          [ { t = I64; lbl = Secret } ]))
+    {
+      memory = None;
+      globals =
+        [
+          {
+            gtype = { t = I64; lbl = Secret };
+            const = [ WI_Const (42, I64) ];
+            mut = false;
+          };
+        ];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body =
+              [
+                WI_GlobalGet 0;
+                WI_Block
+                  (BlockType ([ { t = I64; lbl = Public } ], []), [ WI_Drop ]);
+              ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Block output stack has higher security level than block result security level
+
+  (module
+    (global i64<Secret> (i64.const 42))
+    (func
+      (block ϵ -> i64<Public>
+        global.get 0
+      end)
+    )
+  )
+*)
+let _ =
+  test "block output stack incorrect security level"
+    (neg_test
+       (err_block4 false
+          [ { t = I64; lbl = Public } ]
+          [ { t = I64; lbl = Secret } ]))
+    {
+      memory = None;
+      globals =
+        [
+          {
+            gtype = { t = I64; lbl = Secret };
+            const = [ WI_Const (42, I64) ];
+            mut = false;
+          };
+        ];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body =
+              [
+                WI_Block
+                  ( BlockType ([], [ { t = I64; lbl = Public } ]),
+                    [ WI_GlobalGet 0 ] );
+              ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Function output stack has different length than specified by function type
+
+  (module
+    (func (result i64<Public>)
+      nop
+    )
+  )
+*)
+let _ =
+  test "function output stack incorrect length"
+    (neg_test (err_block2 true 1 0))
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, [ { t = I64; lbl = Public } ]);
+            locals = [];
+            body = [ WI_Nop ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Function output stack has higher security level than result security level
+
+  (module
+    (func (result i64<Public>)
+      nop
+    )
+  )
+*)
+let _ =
+  test "function output stack incorrect security level"
+    (neg_test
+       (err_block4 true
+          [ { t = I64; lbl = Public } ]
+          [ { t = I64; lbl = Secret } ]))
+    {
+      memory = None;
+      globals =
+        [
+          {
+            gtype = { t = I64; lbl = Secret };
+            const = [ WI_Const (42, I64) ];
+            mut = false;
+          };
+        ];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, [ { t = I64; lbl = Public } ]);
+            locals = [];
+            body = [ WI_GlobalGet 0 ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Function body doesn't correspond to function type (too few return values)
+
+  (module
+    (func (result i64)
+      nop
+    )
+  )
+*)
+let _ =
+  test "function body has incorrect type (too few return values)"
+    (neg_test
+       (TypingError "function must leave 1 values on the stack (found 0)"))
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, [ { t = I64; lbl = Public } ]);
+            locals = [];
+            body = [ WI_Nop ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Function body doesn't correspond to function type (too many return values)
+
+  (module
+    (func
+      i64.const 0
+    )
+  )
+*)
+let _ =
+  test "function body has incorrect type (too many return values)"
+    (neg_test
+       (TypingError "function must leave 0 values on the stack (found 1)"))
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body = [ WI_Const (0, I64) ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Good function call
+  (func (result i64)
+      i64.const 0
+  )
+  (func (result i64)
+      call 0
+      i64.const 1
+      i64.add
+  )
+*)
+
+let _ =
+  test "good function call" pos_test
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, [ { t = I64; lbl = Public } ]);
+            locals = [];
+            body = [ WI_Const (0, I64) ];
+            export_name = None;
+          };
+          {
+            ftype = FunType ([], Public, [ { t = I64; lbl = Public } ]);
+            locals = [];
+            body = [ WI_Call 0; WI_Const (1, I64); WI_BinOp (Add, I64) ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Good function call of imported function
+   (import "env" "foo" (func (param i64)))
+
+  (func
+      i64.const 1
+      call 0
+  )
+*)
+
+let _ =
+  test "good function call of imported function" pos_test
+    {
+      memory = None;
+      globals = [];
+      function_imports =
+        [ ("env", "foo", FunType ([ { t = I64; lbl = Public } ], Public, [])) ];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body = [ WI_Const (1, I64); WI_Call 0 ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Function call - not enough arguments provided
+  (func (param i64) (result i64)
+      i64.const 0
+  )
+  (func (result i64)
+      call 0
+  )
+*)
+
+let _ =
+  test "call: not enough arguments provided"
+    (neg_test (TypingError "call needs 1 values on the stack (found 0)"))
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype =
+              FunType
+                ( [ { t = I64; lbl = Public } ],
+                  Public,
+                  [ { t = I64; lbl = Public } ] );
+            locals = [];
+            body = [ WI_Const (0, I64) ];
+            export_name = None;
+          };
+          {
+            ftype = FunType ([], Public, [ { t = I64; lbl = Public } ]);
+            locals = [];
+            body = [ WI_Call 0 ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Call non-existing function
+  (func
+      call 5
+  )
+*)
+
+let _ =
+  test "call non-existing function"
+    (neg_test (TypingError "did not find function of index 5"))
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body = [ WI_Call 5 ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Can't enter function due to Secret parameter flowing to Public arg
+  (global i64<Secret> (i64.const 0))
+  (func <Public> (param i64<Public>)
+      nop
+  )
+  (func <Public>
+      global.get ;; loads secret parameter for call
+      call 0
+  )
+*)
+
+let _ =
+  test "can't enter function due to Secret parameter flowing to Public arg"
+    (neg_test
+       (TypingError
+          "call needs values with types \226\138\145 {i64, Public} :: [] on \
+           the stack (found {i64, Secret} :: [])"))
+    {
+      memory = None;
+      globals =
+        [
+          {
+            gtype = { t = I64; lbl = Secret };
+            const = [ WI_Const (0, I64) ];
+            mut = false;
+          };
+        ];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([ { t = I64; lbl = Public } ], Public, []);
+            locals = [];
+            body = [ WI_Nop ];
+            export_name = None;
+          };
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body = [ WI_GlobalGet 0; WI_Call 0 ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Can't enter Public function with Secret pc
+  (func <Public>
+     nop
+  )
+  (func <Secret>
+      call 0
+  )
+*)
+
+let _ =
+  test "can't enter Public function with Secret pc"
+    (neg_test (err_call1 Public Secret))
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body = [ WI_Nop ];
+            export_name = None;
+          };
+          {
+            ftype = FunType ([], Secret, []);
+            locals = [];
+            body = [ WI_Call 0 ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Test block typechecks
+
+  (func
+  (param i64) (result i64)
+      local.get 0
+      block (param i64) (result i64)
+        nop
+      end
+  )
+*)
+let _ =
+  test "block-1" pos_test
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype =
+              FunType
+                ( [ { t = I64; lbl = Public } ],
+                  Public,
+                  [ { t = I64; lbl = Public } ] );
+            locals = [ { t = I64; lbl = Public } ];
+            body =
+              [
+                WI_LocalGet 0;
+                WI_Block
+                  ( BlockType
+                      ( [ { t = I64; lbl = Public } ],
+                        [ { t = I64; lbl = Public } ] ),
+                    [ WI_Nop ] );
+              ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Test type mismatch at end of block, expected [] but got [i64]
+
+  (func
+  (param i64) (result i64)
+      local.get 0
+      block (param i64)
+        nop
+      end
+  )
+*)
+
+let _ =
+  test "type mismatch at end of block"
+    (neg_test (TypingError "block must leave 0 values on the stack (found 1)"))
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype =
+              FunType
+                ( [ { t = I64; lbl = Public } ],
+                  Public,
+                  [ { t = I64; lbl = Public } ] );
+            locals = [ { t = I64; lbl = Public } ];
+            body =
+              [
+                WI_LocalGet 0;
+                WI_Block
+                  (BlockType ([ { t = I64; lbl = Public } ], []), [ WI_Nop ]);
+              ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Test type mismatch at end of function, expected [] but got [i64, i64]
+
+  (func (result i64)
+      i64.const 1
+      i64.const 2
+      i64.const 3
+  )
+*)
+
+let _ =
+  test "type mismatch at end of function"
+    (neg_test
+       (TypingError "function must leave 1 values on the stack (found 3)"))
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, [ { t = I64; lbl = Public } ]);
+            locals = [];
+            body = [ WI_Const (1, I64); WI_Const (2, I64); WI_Const (3, I64) ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Test func can get its arguments using local.get
+
+  (module
+    (func
+    (param i64) (result i64)
+      local.get 0
+    )
+  )
+*)
+
+let _ =
+  test "func can get it's argument using local.get" pos_test
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype =
+              FunType
+                ( [ { t = I64; lbl = Public } ],
+                  Public,
+                  [ { t = I64; lbl = Public } ] );
+            locals = [];
+            body = [ WI_LocalGet 0 ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Test func can get its arguments using local.get
+
+  (module
+    (func
+    (param i64) (result i64)
+      local.get 0
+    )
+  )
+*)
+let _ =
+  test "func can get it's argument using local.get" pos_test
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype =
+              FunType
+                ( [ { t = I64; lbl = Public } ],
+                  Public,
+                  [ { t = I64; lbl = Public } ] );
+            locals = [];
+            body = [ WI_LocalGet 0 ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Test branch to end of current block
+
+  (module
+    (func
+    (param i64) (result i64)
+      block
+        br 0
+      end
+      i64.const 42
+    )
+  )
+*)
+let _ =
+  test "branch to end of current block" pos_test
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype =
+              FunType
+                ( [ { t = I64; lbl = Public } ],
+                  Public,
+                  [ { t = I64; lbl = Public } ] );
+            locals = [];
+            body = [ WI_Block (BlockType ([], []), [ WI_Br 0 ]); WI_Const (42, I64) ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Bad unconditional branch not enough arguments to return
+
+  (module
+    (func
+    (param i64)
+      block ([] -> [i64])
+        br 0
+      end
+    )
+  )
+*)
+let _ =
+  test "bad unconditional branch not enough arguments to return"
+    (neg_test
+       (TypingError "branching expected at least 1 values on stack (found 0)"))
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, [ { t = I64; lbl = Public } ]);
+            locals = [];
+            body =
+              [
+                WI_Block
+                  (BlockType ([], [ { t = I64; lbl = Public } ]), [ WI_Br 0 ]);
+              ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Test branch to the end of nested block typechecks
+
+  (module
+    (func
+    (param i64) (result i64)
+      block (result i64)
+        block
+          br 0
+        end
+        i64.const 42
+      end
+    )
+  )
+*)
+
+let _ =
+  test "br-2" pos_test
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype =
+              FunType
+                ( [ { t = I64; lbl = Public } ],
+                  Public,
+                  [ { t = I64; lbl = Public } ] );
+            locals = [];
+            body =
+              [
+                WI_Block
+                  ( BlockType ([], [ { t = I64; lbl = Public } ]),
+                    [ WI_Block (BlockType ([], []), [ WI_Br 0 ]); WI_Const (42, I64) ]
+                  );
+              ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Test type mismatch in br, expected [i64] but got []
+
+  (module
+    (func
+    (param i64) (result i64)
+      block (result i64)
+        block
+          br 1
+        end
+        i64.const 42
+      end
+    )
+  )
+*)
+
+let _ =
+  test "type mismatch in br"
+    (neg_test (err_branch_stack_size 1 0))
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype =
+              FunType
+                ( [ { t = I64; lbl = Public } ],
+                  Public,
+                  [ { t = I64; lbl = Public } ] );
+            locals = [];
+            body =
+              [
+                WI_Block
+                  ( BlockType ([], [ { t = I64; lbl = Public } ]),
+                    [ WI_Block (BlockType ([], []), [ WI_Br 1 ]); WI_Const (42, I64) ]
+                  );
+              ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Unconditionally branching outside the implicit function body block
+
+  (module
+    (func
+      br 0
+    )
+  )
+*)
+
+let _ =
+  test "unconditional branching outside implicit function block" pos_test
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body = [ WI_Br 0 ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Unconditionally branching outside a block,
+  or in general to an index that is higher
+  than the nesting depth of blocks
+
+  (module
+    (func
+      br 1
+    )
+  )
+*)
+
+let _ =
+  test "unconditional branching outside block"
+    (neg_test
+       (TypingError "branching to index 1, valid indices range from 0 to 0"))
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body = [ WI_Br 1 ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Unconditionally branching to an invalid index (negative)
+
+  (module
+    (func
+      block
+        br -1
+      end
+    )
+  )
+*)
+
+let _ =
+  test "unconditional branching to invalid index (negative)"
+    (neg_test (err_branch_index (-1) 1))
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body = [ WI_Block (BlockType ([], []), [ WI_Br (-1) ]) ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Test cond branch to end of current block
+
+  (module
+    (func
+    (param i64) (result i64)
+      block
+        i64.const 1
+        br_if 0
+      end
+      i64.const 32
+    )
+  )
+*)
+let _ =
+  test "cond branch to end of current block" pos_test
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype =
+              FunType
+                ( [ { t = I64; lbl = Public } ],
+                  Public,
+                  [ { t = I64; lbl = Public } ] );
+            locals = [];
+            body =
+              [
+                WI_Block (BlockType ([], []), [ WI_Const (1, I64); WI_BrIf 0 ]);
+                WI_Const (42, I64);
+              ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Test cond branch no conditional to branch on
+
+  (module
+    (func
+      block
+        br_if 0
+      end
+    )
+  )
+*)
+let _ =
+  test "no condtional to branch on"
+    (neg_test (TypingError "conditional branch expected 1 value on the stack"))
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body = [ WI_Block (BlockType ([], []), [ WI_BrIf 0 ]) ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Bad conditional branch not enough arguments to return
+
+  (module
+    (func
+    (param i64)
+      block ([] -> [i64])
+        i64.const 0
+        br_if 0
+      end
+    )
+  )
+*)
+let _ =
+  test "bad conditional branch not enough arguments to return"
+    (neg_test
+       (TypingError "branching expected at least 1 values on stack (found 0)"))
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, [ { t = I64; lbl = Public } ]);
+            locals = [];
+            body =
+              [
+                WI_Block
+                  ( BlockType ([], [ { t = I64; lbl = Public } ]),
+                    [ WI_Const (0, I64); WI_BrIf 0 ] );
+              ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Unconditional branch output-val has higher security level than block result security level
+
+  (module
+    (global i64<Secret> (i64.const 42))
+    (func
+      (block ϵ -> i64<Public>
+        global.get 0
+      end)
+    )
+  )
+*)
+let _ =
+  test "unconditional branch: output stack incorrect security level"
+    (neg_test
+       (TypingError
+          "branching expected {i64, Public} :: [] to be a prefix of the stack \
+           ({i64, Secret} :: [])"))
+    {
+      memory = None;
+      globals =
+        [
+          {
+            gtype = { t = I64; lbl = Secret };
+            const = [ WI_Const (42, I64) ];
+            mut = false;
+          };
+        ];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body =
+              [
+                WI_Block
+                  ( BlockType ([], [ { t = I64; lbl = Public } ]),
+                    [ WI_GlobalGet 0; WI_Br 0 ] );
+              ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Conditional branch on secret leaks information
+
+  (module
+    (global i64<Secret> (i64.const 42))
+    (func
+      i64.const 0
+      (block i64 -> i64
+        global.get 0
+        br_if 0
+      end)
+      drop
+    )
+  )
+*)
+let _ =
+  test "conditional branch: branching on secret value"
+    (neg_test
+       (PrivacyViolation
+          "branching expected security level of all values on stack {i64, \
+           Public} :: [] to be strictly greater than Public"))
+    {
+      memory = None;
+      globals =
+        [
+          {
+            gtype = { t = I64; lbl = Secret };
+            const = [ WI_Const (42, I64) ];
+            mut = false;
+          };
+        ];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body =
+              [
+                WI_Block
+                  ( BlockType ([], [ { t = I64; lbl = Public } ]),
+                    [ WI_Const (0, I64); WI_GlobalGet 0; WI_BrIf 0 ] );
+                WI_Drop;
+              ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Conditional branch output-val has higher security level than block result security level
+
+  (module
+    (global i64<Secret> (i64.const 42))
+    (func
+      (block ϵ -> i64<Public>
+        global.get 0
+      end)
+    )
+  )
+*)
+let _ =
+  test "conditional branch: output stack incorrect security level"
+    (neg_test
+       (TypingError
+          "branching expected {i64, Public} :: [] to be a prefix of the stack \
+           ({i64, Secret} :: [])"))
+    {
+      memory = None;
+      globals =
+        [
+          {
+            gtype = { t = I64; lbl = Secret };
+            const = [ WI_Const (42, I64) ];
+            mut = false;
+          };
+        ];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body =
+              [
+                WI_Block
+                  ( BlockType ([], [ { t = I64; lbl = Public } ]),
+                    [ WI_GlobalGet 0; WI_Const (0, I64); WI_BrIf 0 ] );
+              ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Conditional branching to an invalid index (negative)
+
+  (module
+    (func
+      block
+        i64.const 1
+        br -1
+      end
+    )
+  )
+*)
+
+let _ =
+  test "conditional branching to invalid index (negative)"
+    (neg_test (err_branch_index (-1) 1))
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body =
+              [ WI_Block (BlockType ([], []), [ WI_Const (1, I64); WI_BrIf (-1) ]) ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Conditional branching to an invalid index (too large)
+
+  (module
+    (func
+      block
+        i64.const 1
+        br 2
+      end
+    )
+  )
+*)
+
+let _ =
+  test "conditional branching to invalid index (too large)"
+    (neg_test (err_branch_index 2 1))
+    {
+      memory = None;
+      globals = [];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body = [ WI_Block (BlockType ([], []), [ WI_Const (1, I64); WI_BrIf 2 ]) ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Illegal implicit flow that should be caught by lifting pc (br_if)
+
+  (module
+    (global i64<Secret> i64.const 1)
+    (global (mut i64<Public>) i64.const 0)
+    (func
+      block 
+        block 
+          global.get 0
+          i64.const 0
+          i64.eq
+          br_if 1
+        end
+        i64.const 1
+        global.set 1
+      end
+    )
+  )
+*)
+
+let _ =
+  test "illegal implicit flow caught by lift (br_if)"
+    (neg_test (err_globalset2 Secret Secret Public))
+    {
+      memory = None;
+      globals =
+        [
+          {
+            gtype = { t = I64; lbl = Secret };
+            const = [ WI_Const (1, I64) ];
+            mut = false;
+          };
+          {
+            gtype = { t = I64; lbl = Public };
+            const = [ WI_Const (0, I64) ];
+            mut = true;
+          };
+        ];
+      function_imports = [];
+      functions =
+        [
+          {
+            ftype = FunType ([], Public, []);
+            locals = [];
+            body =
+              [
+                WI_Block
+                  ( BlockType ([], []),
+                    [
+                      WI_Block
+                        ( BlockType ([], []),
+                          [ WI_GlobalGet 0; WI_Const (0, I64); WI_BinOp (Eq, I64); WI_BrIf 1 ]
+                        );
+                      WI_Const (1, I64);
+                      WI_GlobalSet 1;
+                    ] );
+              ];
+            export_name = None;
+          };
+        ];
+    }
+
+(*
+  Illegal implicit flow that should be caught by lifting pc (br)
+
+  (module
+    (global i64<Secret> i64.const 1)
+    (global (mut i64<Public>) i64.const 0)
+    (func
+      block 
+        block 
+          global.get 0
+          i64.const 0
+          i64.eq
+          br_if 0
+          br 1
+        end
+        i64.const 1
+        global.set 1
+      end
+    )
+  )
+*)
+
+  let _ =
+    test "illegal implicit flow caught by lift (br)"
+      (neg_test (err_globalset2 Secret Secret Public))
+      {
+        memory = None;
+        globals =
+          [
+            {
+              gtype = { t = I64; lbl = Secret };
+              const = [ WI_Const (1, I64) ];
+              mut = false;
+            };
+            {
+              gtype = { t = I64; lbl = Public };
+              const = [ WI_Const (0, I64) ];
+              mut = true;
+            };
+          ];
+        function_imports = [];
+        functions =
+          [
+            {
+              ftype = FunType ([], Public, []);
+              locals = [];
+              body =
+                [
+                  WI_Block
+                    ( BlockType ([], []),
+                      [
+                        WI_Block
+                          ( BlockType ([], []),
+                            [ WI_GlobalGet 0; WI_Const (0, I64); WI_BinOp (Eq, I64); WI_BrIf 0; WI_Br 1]
+                          );
+                        WI_Const (1, I64);
                         WI_GlobalSet 1;
                       ] );
                 ];

--- a/src/tests/test_secwasm.ml
+++ b/src/tests/test_secwasm.ml
@@ -44,7 +44,7 @@ let _ =
           {
             ftype = FunType ([], Public, [ { t = I32; lbl = Public } ]);
             locals = [];
-            body = [ WI_Const 1; WI_Const 1; WI_BinOp Add ];
+            body = [ WI_Const (1, I32); WI_Const (1, I32); WI_BinOp (Add, I32) ];
             export_name = None;
           };
         ];
@@ -72,7 +72,7 @@ let _ =
           {
             ftype = FunType ([], Public, [ { t = I32; lbl = Public } ]);
             locals = [];
-            body = [ WI_Const 1; WI_BinOp Add ];
+            body = [ WI_Const (1, I32); WI_BinOp (Add, I32) ];
             export_name = None;
           };
         ];
@@ -151,7 +151,7 @@ let _ =
           {
             ftype = FunType ([], Public, []);
             locals = [ { t = I32; lbl = Public } ];
-            body = [ WI_Const 42; WI_Drop ];
+            body = [ WI_Const (42, I32); WI_Drop ];
             export_name = None;
           };
         ];
@@ -258,7 +258,7 @@ let _ =
         [
           {
             gtype = { t = I32; lbl = Public };
-            const = [ WI_Const 0 ];
+            const = [ WI_Const (0, I32) ];
             mut = true;
           };
         ];
@@ -268,7 +268,7 @@ let _ =
           {
             ftype = FunType ([], Public, []);
             locals = [];
-            body = [ WI_Const 42; WI_GlobalSet 0 ];
+            body = [ WI_Const (42, I32); WI_GlobalSet 0 ];
             export_name = None;
           };
         ];
@@ -322,7 +322,7 @@ let _ =
         [
           {
             gtype = { t = I32; lbl = Public };
-            const = [ WI_Const 0 ];
+            const = [ WI_Const (0, I32) ];
             mut = false;
           };
         ];
@@ -332,7 +332,7 @@ let _ =
           {
             ftype = FunType ([], Public, []);
             locals = [];
-            body = [ WI_Const 42; WI_GlobalSet 0 ];
+            body = [ WI_Const (42, I32); WI_GlobalSet 0 ];
             export_name = None;
           };
         ];
@@ -360,7 +360,7 @@ let _ =
           {
             ftype = FunType ([], Public, []);
             locals = [];
-            body = [ WI_Const 42; WI_GlobalSet 0 ];
+            body = [ WI_Const (42, I32); WI_GlobalSet 0 ];
             export_name = None;
           };
         ];
@@ -392,12 +392,12 @@ let _ =
         [
           {
             gtype = { t = I32; lbl = Secret };
-            const = [ WI_Const 0 ];
+            const = [ WI_Const (0, I32) ];
             mut = false;
           };
           {
             gtype = { t = I32; lbl = Public };
-            const = [ WI_Const 0 ];
+            const = [ WI_Const (0, I32) ];
             mut = true;
           };
         ];
@@ -407,7 +407,7 @@ let _ =
           {
             ftype = FunType ([], Public, []);
             locals = [];
-            body = [ WI_GlobalGet 0; WI_Const 1; WI_BinOp Add; WI_GlobalSet 1 ];
+            body = [ WI_GlobalGet 0; WI_Const (1, I32); WI_BinOp (Add, I32); WI_GlobalSet 1 ];
             export_name = None;
           };
         ];
@@ -435,7 +435,7 @@ let _ =
           {
             ftype = FunType ([], Public, []);
             locals = [ { t = I32; lbl = Public } ];
-            body = [ WI_Const 42; WI_LocalSet 0 ];
+            body = [ WI_Const (42, I32); WI_LocalSet 0 ];
             export_name = None;
           };
         ];
@@ -493,7 +493,7 @@ let _ =
         [
           {
             gtype = { t = I32; lbl = Secret };
-            const = [ WI_Const 0 ];
+            const = [ WI_Const (0, I32) ];
             mut = false;
           };
         ];
@@ -531,7 +531,7 @@ let _ =
           {
             ftype = FunType ([], Public, [ { t = I32; lbl = Public } ]);
             locals = [];
-            body = [ WI_Const 0; WI_Load Public ];
+            body = [ WI_Const (0, I32); WI_Load (Public, I32) ];
             export_name = None;
           };
         ];
@@ -559,7 +559,7 @@ let _ =
           {
             ftype = FunType ([], Public, [ { t = I32; lbl = Public } ]);
             locals = [];
-            body = [ WI_Load Public ];
+            body = [ WI_Load (Public, I32) ];
             export_name = None;
           };
         ];
@@ -587,7 +587,7 @@ let _ =
           {
             ftype = FunType ([], Public, [ { t = I32; lbl = Public } ]);
             locals = [];
-            body = [ WI_Const 0; WI_Load Public ];
+            body = [ WI_Const (0, I32); WI_Load (Public, I32) ];
             export_name = None;
           };
         ];
@@ -615,7 +615,7 @@ let _ =
           {
             ftype = FunType ([], Public, []);
             locals = [];
-            body = [ WI_Const 0; WI_Const 0; WI_Store Public ];
+            body = [ WI_Const (0, I32); WI_Const (0, I32); WI_Store (Public, I32) ];
             export_name = None;
           };
         ];
@@ -644,7 +644,7 @@ let _ =
           {
             ftype = FunType ([], Public, []);
             locals = [];
-            body = [ WI_Const 0; WI_Const 42; WI_Store Public ];
+            body = [ WI_Const (0, I32); WI_Const (42, I32); WI_Store (Public, I32) ];
             export_name = None;
           };
         ];
@@ -675,7 +675,7 @@ let _ =
         [
           {
             gtype = { t = I32; lbl = Secret };
-            const = [ WI_Const 0 ];
+            const = [ WI_Const (0, I32) ];
             mut = false;
           };
         ];
@@ -685,7 +685,7 @@ let _ =
           {
             ftype = FunType ([], Public, []);
             locals = [];
-            body = [ WI_Const 0; WI_GlobalGet 0; WI_Store Public ];
+            body = [ WI_Const (0, I32); WI_GlobalGet 0; WI_Store (Public, I32) ];
             export_name = None;
           };
         ];
@@ -713,7 +713,7 @@ let _ =
           {
             ftype = FunType ([], Public, [ { t = I32; lbl = Public } ]);
             locals = [];
-            body = [ WI_Store Public ];
+            body = [ WI_Store (Public, I32) ];
             export_name = None;
           };
         ];
@@ -745,12 +745,12 @@ let _ =
         [
           {
             gtype = { t = I32; lbl = Secret };
-            const = [ WI_Const 0 ];
+            const = [ WI_Const (0, I32) ];
             mut = false;
           };
           {
             gtype = { t = I32; lbl = Public };
-            const = [ WI_Const 0 ];
+            const = [ WI_Const (0, I32) ];
             mut = true;
           };
         ];
@@ -760,7 +760,7 @@ let _ =
           {
             ftype = FunType ([], Public, []);
             locals = [];
-            body = [ WI_GlobalGet 0; WI_Load Public; WI_GlobalSet 1 ];
+            body = [ WI_GlobalGet 0; WI_Load (Public, I32); WI_GlobalSet 1 ];
             export_name = None;
           };
         ];
@@ -854,7 +854,7 @@ let _ =
             locals = [];
             body =
               [
-                WI_Const 42;
+                WI_Const (42, I32);
                 WI_Block
                   (BlockType ([ { t = I32; lbl = Public } ], []), [ WI_Drop ]);
               ];
@@ -921,7 +921,7 @@ let _ =
             locals = [];
             body =
               [
-                WI_Const 42;
+                WI_Const (42, I32);
                 WI_Block
                   ( BlockType
                       ( [ { t = I32; lbl = Public } ],
@@ -958,7 +958,7 @@ let _ =
         [
           {
             gtype = { t = I32; lbl = Secret };
-            const = [ WI_Const 42 ];
+            const = [ WI_Const (42, I32) ];
             mut = false;
           };
         ];
@@ -1003,7 +1003,7 @@ let _ =
         [
           {
             gtype = { t = I32; lbl = Secret };
-            const = [ WI_Const 42 ];
+            const = [ WI_Const (42, I32) ];
             mut = false;
           };
         ];
@@ -1072,7 +1072,7 @@ let _ =
         [
           {
             gtype = { t = I32; lbl = Secret };
-            const = [ WI_Const 42 ];
+            const = [ WI_Const (42, I32) ];
             mut = false;
           };
         ];
@@ -1138,7 +1138,7 @@ let _ =
           {
             ftype = FunType ([], Public, []);
             locals = [];
-            body = [ WI_Const 0 ];
+            body = [ WI_Const (0, I32) ];
             export_name = None;
           };
         ];
@@ -1167,13 +1167,13 @@ let _ =
           {
             ftype = FunType ([], Public, [ { t = I32; lbl = Public } ]);
             locals = [];
-            body = [ WI_Const 0 ];
+            body = [ WI_Const (0, I32) ];
             export_name = None;
           };
           {
             ftype = FunType ([], Public, [ { t = I32; lbl = Public } ]);
             locals = [];
-            body = [ WI_Call 0; WI_Const 1; WI_BinOp Add ];
+            body = [ WI_Call 0; WI_Const (1, I32); WI_BinOp (Add, I32) ];
             export_name = None;
           };
         ];
@@ -1201,7 +1201,7 @@ let _ =
           {
             ftype = FunType ([], Public, []);
             locals = [];
-            body = [ WI_Const 1; WI_Call 0 ];
+            body = [ WI_Const (1, I32); WI_Call 0 ];
             export_name = None;
           };
         ];
@@ -1233,7 +1233,7 @@ let _ =
                   Public,
                   [ { t = I32; lbl = Public } ] );
             locals = [];
-            body = [ WI_Const 0 ];
+            body = [ WI_Const (0, I32) ];
             export_name = None;
           };
           {
@@ -1294,7 +1294,7 @@ let _ =
         [
           {
             gtype = { t = I32; lbl = Secret };
-            const = [ WI_Const 0 ];
+            const = [ WI_Const (0, I32) ];
             mut = false;
           };
         ];
@@ -1452,7 +1452,7 @@ let _ =
           {
             ftype = FunType ([], Public, [ { t = I32; lbl = Public } ]);
             locals = [];
-            body = [ WI_Const 1; WI_Const 2; WI_Const 3 ];
+            body = [ WI_Const (1, I32); WI_Const (2, I32); WI_Const (3, I32) ];
             export_name = None;
           };
         ];
@@ -1549,7 +1549,7 @@ let _ =
                   Public,
                   [ { t = I32; lbl = Public } ] );
             locals = [];
-            body = [ WI_Block (BlockType ([], []), [ WI_Br 0 ]); WI_Const 42 ];
+            body = [ WI_Block (BlockType ([], []), [ WI_Br 0 ]); WI_Const (42, I32) ];
             export_name = None;
           };
         ];
@@ -1625,7 +1625,7 @@ let _ =
               [
                 WI_Block
                   ( BlockType ([], [ { t = I32; lbl = Public } ]),
-                    [ WI_Block (BlockType ([], []), [ WI_Br 0 ]); WI_Const 42 ]
+                    [ WI_Block (BlockType ([], []), [ WI_Br 0 ]); WI_Const (42, I32) ]
                   );
               ];
             export_name = None;
@@ -1669,7 +1669,7 @@ let _ =
               [
                 WI_Block
                   ( BlockType ([], [ { t = I32; lbl = Public } ]),
-                    [ WI_Block (BlockType ([], []), [ WI_Br 1 ]); WI_Const 42 ]
+                    [ WI_Block (BlockType ([], []), [ WI_Br 1 ]); WI_Const (42, I32) ]
                   );
               ];
             export_name = None;
@@ -1796,8 +1796,8 @@ let _ =
             locals = [];
             body =
               [
-                WI_Block (BlockType ([], []), [ WI_Const 1; WI_BrIf 0 ]);
-                WI_Const 42;
+                WI_Block (BlockType ([], []), [ WI_Const (1, I32); WI_BrIf 0 ]);
+                WI_Const (42, I32);
               ];
             export_name = None;
           };
@@ -1863,7 +1863,7 @@ let _ =
               [
                 WI_Block
                   ( BlockType ([], [ { t = I32; lbl = Public } ]),
-                    [ WI_Const 0; WI_BrIf 0 ] );
+                    [ WI_Const (0, I32); WI_BrIf 0 ] );
               ];
             export_name = None;
           };
@@ -1894,7 +1894,7 @@ let _ =
         [
           {
             gtype = { t = I32; lbl = Secret };
-            const = [ WI_Const 42 ];
+            const = [ WI_Const (42, I32) ];
             mut = false;
           };
         ];
@@ -1942,7 +1942,7 @@ let _ =
         [
           {
             gtype = { t = I32; lbl = Secret };
-            const = [ WI_Const 42 ];
+            const = [ WI_Const (42, I32) ];
             mut = false;
           };
         ];
@@ -1956,7 +1956,7 @@ let _ =
               [
                 WI_Block
                   ( BlockType ([], [ { t = I32; lbl = Public } ]),
-                    [ WI_Const 0; WI_GlobalGet 0; WI_BrIf 0 ] );
+                    [ WI_Const (0, I32); WI_GlobalGet 0; WI_BrIf 0 ] );
                 WI_Drop;
               ];
             export_name = None;
@@ -1988,7 +1988,7 @@ let _ =
         [
           {
             gtype = { t = I32; lbl = Secret };
-            const = [ WI_Const 42 ];
+            const = [ WI_Const (42, I32) ];
             mut = false;
           };
         ];
@@ -2002,7 +2002,7 @@ let _ =
               [
                 WI_Block
                   ( BlockType ([], [ { t = I32; lbl = Public } ]),
-                    [ WI_GlobalGet 0; WI_Const 0; WI_BrIf 0 ] );
+                    [ WI_GlobalGet 0; WI_Const (0, I32); WI_BrIf 0 ] );
               ];
             export_name = None;
           };
@@ -2035,7 +2035,7 @@ let _ =
             ftype = FunType ([], Public, []);
             locals = [];
             body =
-              [ WI_Block (BlockType ([], []), [ WI_Const 1; WI_BrIf (-1) ]) ];
+              [ WI_Block (BlockType ([], []), [ WI_Const (1, I32); WI_BrIf (-1) ]) ];
             export_name = None;
           };
         ];
@@ -2066,7 +2066,7 @@ let _ =
           {
             ftype = FunType ([], Public, []);
             locals = [];
-            body = [ WI_Block (BlockType ([], []), [ WI_Const 1; WI_BrIf 2 ]) ];
+            body = [ WI_Block (BlockType ([], []), [ WI_Const (1, I32); WI_BrIf 2 ]) ];
             export_name = None;
           };
         ];
@@ -2102,12 +2102,12 @@ let _ =
         [
           {
             gtype = { t = I32; lbl = Secret };
-            const = [ WI_Const 1 ];
+            const = [ WI_Const (1, I32) ];
             mut = false;
           };
           {
             gtype = { t = I32; lbl = Public };
-            const = [ WI_Const 0 ];
+            const = [ WI_Const (0, I32) ];
             mut = true;
           };
         ];
@@ -2124,9 +2124,9 @@ let _ =
                     [
                       WI_Block
                         ( BlockType ([], []),
-                          [ WI_GlobalGet 0; WI_Const 0; WI_BinOp Eq; WI_BrIf 1 ]
+                          [ WI_GlobalGet 0; WI_Const (0, I32); WI_BinOp (Eq, I32); WI_BrIf 1 ]
                         );
-                      WI_Const 1;
+                      WI_Const (1, I32);
                       WI_GlobalSet 1;
                     ] );
               ];
@@ -2166,12 +2166,12 @@ let _ =
           [
             {
               gtype = { t = I32; lbl = Secret };
-              const = [ WI_Const 1 ];
+              const = [ WI_Const (1, I32) ];
               mut = false;
             };
             {
               gtype = { t = I32; lbl = Public };
-              const = [ WI_Const 0 ];
+              const = [ WI_Const (0, I32) ];
               mut = true;
             };
           ];
@@ -2188,9 +2188,9 @@ let _ =
                       [
                         WI_Block
                           ( BlockType ([], []),
-                            [ WI_GlobalGet 0; WI_Const 0; WI_BinOp Eq; WI_BrIf 0; WI_Br 1]
+                            [ WI_GlobalGet 0; WI_Const (0, I32); WI_BinOp (Eq, I32); WI_BrIf 0; WI_Br 1]
                           );
-                        WI_Const 1;
+                        WI_Const (1, I32);
                         WI_GlobalSet 1;
                       ] );
                 ];


### PR DESCRIPTION
Added support for `i64` primitive types: 
- Modified type checking & pretty printing of the following `wasm_instruction` types and they will now require a `value_type` when used:
  - `WI_Const`
  - `WI_BinOp`
  - `WI_Load`
  - `WI_Store`
- Modified pretty printing for globals (`WI_GlobalGet` & `WI_GlobalSet`) to support i64 
- Added type checking tests for i64