### PR TITLE
If-then-else

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 _build/
 _coverage/
 _benchmark/
+_demo/
 
 # ocamlbuild targets
 *.byte

--- a/src/Makefile
+++ b/src/Makefile
@@ -4,6 +4,14 @@ help:
 	dune build
 	dune exec _build/default/bin/main.exe -- -help
 
+demo:
+	dune build
+	rm -rf _demo
+	mkdir -p _demo
+	dune exec _build/default/bin/main.exe -- -example demo$(num) -pp -out _demo/orig.wat
+	cd _demo && wat2wasm orig.wat
+	node ../testing/examples/demo.js
+	dune exec _build/default/bin/main.exe -- -example demo$(num) -typecheck
 run:
 	dune build
 	dune exec _build/default/bin/main.exe -- -example 1 -typecheck
@@ -71,3 +79,4 @@ coverage:
 	bisect-ppx-report summary
 	@echo "======================"
 	@echo "For summary see _coverage/index.html"
+

--- a/src/lib/ast.ml
+++ b/src/lib/ast.ml
@@ -81,7 +81,15 @@ let pp_labeled_type (t : labeled_value_type) =
   pp_type t.t (* TODO: have separate pp <== what is meant by this? *)
 
 let nl = "\n"
-
+let pp_if_else_type (BlockType (_, bt_out)) =
+  let result =
+    if List.length bt_out > 0 then
+      " (result"
+      ^ List.fold_left (fun _s l -> " " ^ pp_labeled_type l ^ _s) "" bt_out
+      ^ ")"
+    else ""
+  in
+  result
 let pp_block_type (BlockType (bt_in, bt_out)) =
   let params =
     if List.length bt_in > 0 then
@@ -149,7 +157,7 @@ let rec pp_instruction (indent : int) (instr : wasm_instruction) =
   | WI_Br idx -> "br " ^ Int.to_string idx
   | WI_BrIf idx -> "br_if " ^ Int.to_string idx
   | WI_IfElse (t, then_br, else_br) ->
-    "if " ^ pp_block_type t ^ nl 
+    "if " ^ pp_if_else_type t ^ nl 
     ^ pp_instructions (indent + 2) then_br 
     ^ spaces indent ^ "else" ^ nl
     ^ pp_instructions (indent + 2) else_br

--- a/src/lib/ast.ml
+++ b/src/lib/ast.ml
@@ -29,22 +29,23 @@ type binop =
 [@@@ocamlformat "disable"]
 
 type wasm_instruction =
-  | WI_Unreachable                                                    (* trap unconditionally *)
-  | WI_Drop                                                           (* drop value *)
-  | WI_Const of (int * value_type)                                    (* constant *)
-  | WI_BinOp of (binop * value_type)                                  (* binary numeric operator, deviates a bit from spec *)
-  | WI_Call of int                                                    (* call function *)
-  | WI_LocalGet of int                                                (* read local variable *)
-  | WI_LocalSet of int                                                (* write local variable *)
-  | WI_GlobalGet of int                                               (* read global variable *)
-  | WI_GlobalSet of int                                               (* write global variable *)
-  | WI_Load of (SimpleLattice.t * value_type)                         (* read memory at address *)
-  | WI_Store of (SimpleLattice.t * value_type)                        (* write memory at address *)
-  | WI_Block of block_type * wasm_instruction list                    (* block *)
-  | WI_Loop of block_type * wasm_instruction list                     (* loop *)
-  | WI_Br of int                                                      (* unconditional branch *)
-  | WI_BrIf of int                                                    (* conditional branch *)
-  | WI_Nop
+  | WI_Unreachable                                                              (* trap unconditionally *)
+  | WI_Drop                                                                     (* drop value *)
+  | WI_Const of (int * value_type)                                              (* constant *)
+  | WI_BinOp of (binop * value_type)                                            (* binary numeric operator, deviates a bit from spec *)
+  | WI_Call of int                                                              (* call function *)
+  | WI_LocalGet of int                                                          (* read local variable *)
+  | WI_LocalSet of int                                                          (* write local variable *)
+  | WI_GlobalGet of int                                                         (* read global variable *)
+  | WI_GlobalSet of int                                                         (* write global variable *)
+  | WI_Load of (SimpleLattice.t * value_type)                                   (* read memory at address *)
+  | WI_Store of (SimpleLattice.t * value_type)                                  (* write memory at address *)
+  | WI_Block of block_type * wasm_instruction list                              (* block *)
+  | WI_Loop of block_type * wasm_instruction list                               (* loop *)
+  | WI_Br of int                                                                (* unconditional branch *)
+  | WI_BrIf of int                                                              (* conditional branch *)
+  | WI_Nop                                                                      (* nop instruction *)
+  | WI_IfElse of block_type * wasm_instruction list * wasm_instruction list     (* if-then-else *)
 
 [@@@ocamlformat "enable"]
 
@@ -147,6 +148,12 @@ let rec pp_instruction (indent : int) (instr : wasm_instruction) =
       ^ spaces indent ^ "end"
   | WI_Br idx -> "br " ^ Int.to_string idx
   | WI_BrIf idx -> "br_if " ^ Int.to_string idx
+  | WI_IfElse (t, then_br, else_br) ->
+    "if " ^ pp_block_type t ^ nl 
+    ^ pp_instructions (indent + 2) then_br 
+    ^ spaces indent ^ "else" ^ nl
+    ^ pp_instructions (indent + 2) else_br
+    ^ spaces indent ^ "end"
 
 let pp_fn_params ftype =
   let ps = match ftype with FunType (plist, _, _) -> plist in

--- a/testing/examples/demo.js
+++ b/testing/examples/demo.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const bytes = fs.readFileSync('_demo/orig.wasm');
+const val_1 = BigInt(0);
+const val_2 = BigInt(1);
+
+(async () => {
+    const obj = await WebAssembly.instantiate(
+        new Uint8Array (bytes), {}
+    );
+    console.log(`Calling function with inputs: ${val_1}, ${val_2}`);
+    let resAlt = obj.instance.exports.hello(val_1, val_2);
+    console.log(`===> ${resAlt}`);
+})();


### PR DESCRIPTION
To implement if-then-else block:
* new wasm instruction in AST: `WI_IfElse`
* pretty printing support for `WI_IfElse`
* implemented type checking for `WI_IfElse`
* added several test cases for `WI_IfElse`
* created some demo modules to showcase certain violations to information flow:
  * new `demo` rule added to `Makefile` 

Improvements to `I64` primitive implementation:
* Handled certain `WI_BinOp` type checking cases 